### PR TITLE
Update Nide8 domain

### DIFF
--- a/src/modules/auth/Nide8Account.ts
+++ b/src/modules/auth/Nide8Account.ts
@@ -7,7 +7,7 @@ export class Nide8Account extends AuthlibAccount {
   constructor(accountName: string, serverId: string) {
     super(
       accountName,
-      `https://auth2.nide8.com:233/${serverId}`,
+      `https://auth.mc-user.com:233/${serverId}`,
       AccountType.NIDE8
     );
     this.serverId = serverId;


### PR DESCRIPTION
Update Nide8 domain, due to some reason, cmcc internet provider blocks the universal login domain. needs update.